### PR TITLE
feat(data): Add CSV export and delete all data functionality

### DIFF
--- a/app/src/main/java/com/example/librehabit/MainActivity.kt
+++ b/app/src/main/java/com/example/librehabit/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -53,6 +54,8 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colorScheme.background
                 ) {
                     val navController = rememberNavController()
+                    val context = LocalContext.current
+
                     NavHost(navController = navController, startDestination = "main") {
                         composable("main") {
                             val entries by weightViewModel.allEntries.collectAsState()
@@ -93,6 +96,12 @@ class MainActivity : ComponentActivity() {
                                 onCheckForUpdates = { settingsViewModel.checkForUpdates() },
                                 onResetUpdateState = { settingsViewModel.resetUpdateState() },
                                 appVersion = BuildConfig.VERSION_NAME,
+                                onExportData = { uri ->
+                                    weightViewModel.exportToCsv(uri, context.contentResolver)
+                                },
+                                onDeleteAllData = {
+                                    weightViewModel.deleteAllData()
+                                },
                                 onNavigateUp = { navController.popBackStack() }
                             )
                         }

--- a/app/src/main/java/com/example/librehabit/WeightDao.kt
+++ b/app/src/main/java/com/example/librehabit/WeightDao.kt
@@ -12,12 +12,15 @@ interface WeightDao {
     @Insert
     suspend fun insert(entry: WeightEntry)
 
-    @Update
-    suspend fun update(entry: WeightEntry)
+    @Query("SELECT * FROM weight_entries ORDER BY date DESC")
+    fun getAllEntries(): Flow<List<WeightEntry>>
 
     @Delete
     suspend fun delete(entry: WeightEntry)
 
-    @Query("SELECT * FROM weight_entries ORDER BY date DESC")
-    fun getAllEntries(): Flow<List<WeightEntry>>
+    @Update
+    suspend fun update(entry: WeightEntry)
+
+    @Query("DELETE FROM weight_entries")
+    suspend fun deleteAll()
 }


### PR DESCRIPTION
This adds a 'Data Management' section to Settings. Users can now export their history to CSV (Closes #4) and securely delete all data via a confirmed 'Danger Zone' action.