### PR TITLE
feat(ui): Add empty states for Graph and History

### DIFF
--- a/app/src/androidTest/java/com/paulhenryp/librehabit/WeightViewModelTest.kt
+++ b/app/src/androidTest/java/com/paulhenryp/librehabit/WeightViewModelTest.kt
@@ -60,7 +60,7 @@ class WeightViewModelTest {
 
         // When
         viewModel.saveWeight(weightValue, date)
-        
+
         val allEntries = viewModel.allEntries.filter { it.isNotEmpty() }.first()
 
         // Then

--- a/app/src/main/java/com/paulhenryp/librehabit/GraphScreen.kt
+++ b/app/src/main/java/com/paulhenryp/librehabit/GraphScreen.kt
@@ -5,25 +5,39 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.paulhenryp.librehabit.ui.components.EmptyState
 import com.patrykandpatrick.vico.compose.axis.horizontal.rememberBottomAxis
 import com.patrykandpatrick.vico.compose.axis.vertical.rememberStartAxis
 import com.patrykandpatrick.vico.compose.chart.Chart
 import com.patrykandpatrick.vico.compose.chart.line.lineChart
+import com.patrykandpatrick.vico.compose.component.shape.shader.fromBrush
+import com.patrykandpatrick.vico.compose.component.shapeComponent
+import com.patrykandpatrick.vico.compose.component.textComponent
+import com.patrykandpatrick.vico.compose.dimensions.dimensionsOf
 import com.patrykandpatrick.vico.compose.m3.style.m3ChartStyle
 import com.patrykandpatrick.vico.compose.style.ProvideChartStyle
 import com.patrykandpatrick.vico.core.axis.AxisItemPlacer
 import com.patrykandpatrick.vico.core.axis.AxisPosition
 import com.patrykandpatrick.vico.core.axis.formatter.AxisValueFormatter
+import com.patrykandpatrick.vico.core.chart.line.LineChart
+import com.patrykandpatrick.vico.core.component.shape.Shapes
+import com.patrykandpatrick.vico.core.component.shape.shader.DynamicShaders
 import com.patrykandpatrick.vico.core.entry.ChartEntryModelProducer
 import com.patrykandpatrick.vico.core.entry.entryOf
 import java.text.SimpleDateFormat
-import java.util.Locale
+import java.util.*
+
+private const val DATA_POINT_VISIBILITY_THRESHOLD = 20
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -45,6 +59,14 @@ fun GraphScreen(
             }
         chartModelProducer.setEntries(chartEntries)
     }
+
+    val dataLabel = textComponent(
+        color = MaterialTheme.colorScheme.onSurface,
+        textSize = 10.sp,
+        background = shapeComponent(Shapes.pillShape, MaterialTheme.colorScheme.surfaceVariant),
+        padding = dimensionsOf(horizontal = 6.dp, vertical = 2.dp)
+    )
+    val dataPoint = shapeComponent(Shapes.pillShape, MaterialTheme.colorScheme.primary)
 
     val bottomAxisValueFormatter =
         AxisValueFormatter<AxisPosition.Horizontal.Bottom> { value, _ ->
@@ -83,21 +105,22 @@ fun GraphScreen(
     ) { paddingValues ->
         Column(modifier = Modifier.padding(paddingValues)) {
             if (entries.size < 2) {
-                Text(
-                    text = "You need at least two entries to draw a graph.",
-                    modifier = Modifier.padding(16.dp),
-                    style = MaterialTheme.typography.bodyLarge
+                EmptyState(
+                    message = "Not enough data.\nAdd at least two entries to see your progress graph.",
+                    icon = Icons.AutoMirrored.Filled.ShowChart
                 )
             } else {
                 ProvideChartStyle(chartStyle = chartStyle) {
                     Chart(
-                        chart = lineChart(),
+                        chart = lineChart(
+
+                        ),
                         chartModelProducer = chartModelProducer,
                         startAxis = rememberStartAxis(
                             title = "Weight (${if (unitSystem == UnitSystem.METRIC) "kg" else "lbs"})",
                             valueFormatter = startAxisValueFormatter,
                             itemPlacer = AxisItemPlacer.Vertical.default(
-                                maxItemCount = 10
+                                maxItemCount = 5
                             )
                         ),
                         bottomAxis = rememberBottomAxis(

--- a/app/src/main/java/com/paulhenryp/librehabit/MainScreen.kt
+++ b/app/src/main/java/com/paulhenryp/librehabit/MainScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -20,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import com.paulhenryp.librehabit.ui.components.EmptyState // <-- Import the new component
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -141,22 +143,32 @@ fun LibreHabitScreen(
                 style = MaterialTheme.typography.headlineSmall,
                 modifier = Modifier.padding(top = 16.dp)
             )
-            LazyColumn(modifier = Modifier.fillMaxWidth()) {
-                items(entries) { entry ->
-                    HistoryItem(
-                        entry = entry,
-                        onDelete = { onDeleteEntry(entry) },
-                        onEdit = { editingEntry = entry },
-                        unitSystem = unitSystem,
-                        height = height,
-                        calculateBmi = calculateBmi
-                    )
+
+            if (entries.isEmpty()) {
+                EmptyState(
+                    message = "No entries yet.\nAdd your first weight above!",
+                    icon = Icons.Default.History,
+                    modifier = Modifier.weight(1f) // Fill remaining space
+                )
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                    items(entries) { entry ->
+                        HistoryItem(
+                            entry = entry,
+                            onDelete = { onDeleteEntry(entry) },
+                            onEdit = { editingEntry = entry },
+                            unitSystem = unitSystem,
+                            height = height,
+                            calculateBmi = calculateBmi
+                        )
+                    }
                 }
             }
         }
     }
 }
 
+// ... (HistoryItem and EditWeightDialog are unchanged) ...
 @Composable
 fun HistoryItem(
     entry: WeightEntry,

--- a/app/src/main/java/com/paulhenryp/librehabit/ui/components/EmptyState.kt
+++ b/app/src/main/java/com/paulhenryp/librehabit/ui/components/EmptyState.kt
@@ -1,0 +1,49 @@
+package com.paulhenryp.librehabit.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EmptyState(
+    message: String,
+    icon: ImageVector? = null,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        if (icon != null) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(72.dp),
+                tint = MaterialTheme.colorScheme.surfaceVariant
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+        Text(
+            text = message,
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}


### PR DESCRIPTION
Introduces a reusable EmptyState component. Displays friendly messages when history is empty or graph has insufficient data. Also fixes Vico graph configuration for version 1.14.0. Closes #19.