### PR TITLE
feat(data): Add data model and DB schema for generic habits

### DIFF
--- a/app/src/main/java/com/paulhenryp/librehabit/AppDatabase.kt
+++ b/app/src/main/java/com/paulhenryp/librehabit/AppDatabase.kt
@@ -5,16 +5,37 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [WeightEntry::class], version = 1, exportSchema = false)
+@Database(
+    entities =[WeightEntry::class, Habit::class, HabitEntry::class],
+    version = 2,
+    exportSchema = false
+)
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
 
     abstract fun weightDao(): WeightDao
+    abstract fun habitDao(): HabitDao
 
     companion object {
         @Volatile
         private var INSTANCE: AppDatabase? = null
+
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `habits` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `goal` REAL, `unit` TEXT, `creationDate` INTEGER NOT NULL)"
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `habit_entries` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `habitId` INTEGER NOT NULL, `date` INTEGER NOT NULL, `value` REAL NOT NULL, FOREIGN KEY(`habitId`) REFERENCES `habits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_habit_entries_habitId` ON `habit_entries` (`habitId`)"
+                )
+            }
+        }
 
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
@@ -22,7 +43,9 @@ abstract class AppDatabase : RoomDatabase() {
                     context.applicationContext,
                     AppDatabase::class.java,
                     "libre_habit_database"
-                ).build()
+                )
+                    .addMigrations(MIGRATION_1_2)
+                    .build()
                 INSTANCE = instance
                 instance
             }

--- a/app/src/main/java/com/paulhenryp/librehabit/Converters.kt
+++ b/app/src/main/java/com/paulhenryp/librehabit/Converters.kt
@@ -13,4 +13,14 @@ class Converters {
     fun dateToTimestamp(date: Date?): Long? {
         return date?.time
     }
+
+    @TypeConverter
+    fun fromHabitType(value: HabitType): String {
+        return value.name
+    }
+
+    @TypeConverter
+    fun toHabitType(value: String): HabitType {
+        return HabitType.valueOf(value)
+    }
 }

--- a/app/src/main/java/com/paulhenryp/librehabit/Habit.kt
+++ b/app/src/main/java/com/paulhenryp/librehabit/Habit.kt
@@ -1,0 +1,16 @@
+package com.paulhenryp.librehabit
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.util.Date
+
+@Entity(tableName = "habits")
+data class Habit(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    val name: String,
+    val type: HabitType,
+    val goal: Float?,
+    val unit: String?,
+    val creationDate: Date
+)

--- a/app/src/main/java/com/paulhenryp/librehabit/HabitDao.kt
+++ b/app/src/main/java/com/paulhenryp/librehabit/HabitDao.kt
@@ -1,0 +1,37 @@
+package com.paulhenryp.librehabit
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+import java.util.Date
+
+@Dao
+interface HabitDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertHabit(habit: Habit)
+
+    @Update
+    suspend fun updateHabit(habit: Habit)
+
+    @Delete
+    suspend fun deleteHabit(habit: Habit)
+
+    @Query("SELECT * FROM habits ORDER BY creationDate DESC")
+    fun getAllHabits(): Flow<List<Habit>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertHabitEntry(entry: HabitEntry)
+
+    @Query("SELECT * FROM habit_entries WHERE date = :date")
+    fun getHabitEntriesForDate(date: Date): Flow<List<HabitEntry>>
+
+    @Query("DELETE FROM habits")
+    suspend fun deleteAllHabits()
+
+    @Query("DELETE FROM habit_entries")
+    suspend fun deleteAllHabitEntries()
+}

--- a/app/src/main/java/com/paulhenryp/librehabit/HabitEntry.kt
+++ b/app/src/main/java/com/paulhenryp/librehabit/HabitEntry.kt
@@ -1,0 +1,27 @@
+package com.paulhenryp.librehabit
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.util.Date
+
+@Entity(
+    tableName = "habit_entries",
+    foreignKeys =[
+        ForeignKey(
+            entity = Habit::class,
+            parentColumns = ["id"],
+            childColumns = ["habitId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("habitId")]
+)
+data class HabitEntry(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    val habitId: Int,
+    val date: Date,
+    val value: Float
+)

--- a/app/src/main/java/com/paulhenryp/librehabit/HabitType.kt
+++ b/app/src/main/java/com/paulhenryp/librehabit/HabitType.kt
@@ -1,0 +1,6 @@
+package com.paulhenryp.librehabit
+
+enum class HabitType {
+    CHECKMARK,
+    NUMERIC
+}

--- a/app/src/main/java/com/paulhenryp/librehabit/WeightViewModel.kt
+++ b/app/src/main/java/com/paulhenryp/librehabit/WeightViewModel.kt
@@ -3,7 +3,6 @@ package com.paulhenryp.librehabit
 import android.app.Application
 import android.content.ContentResolver
 import android.net.Uri
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -13,8 +12,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import java.io.BufferedReader
-import java.io.InputStreamReader
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -49,6 +46,8 @@ class WeightViewModel(private val database: AppDatabase) : ViewModel() {
     fun deleteAllData() {
         viewModelScope.launch {
             database.weightDao().deleteAll()
+            database.habitDao().deleteAllHabitEntries()
+            database.habitDao().deleteAllHabits()
         }
     }
 
@@ -86,15 +85,15 @@ class WeightViewModel(private val database: AppDatabase) : ViewModel() {
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val inputStream = contentResolver.openInputStream(uri)
-                val reader = BufferedReader(InputStreamReader(inputStream))
+                val reader = inputStream?.bufferedReader()
                 val entriesToAdd = mutableListOf<WeightEntry>()
 
                 val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
                 dateFormat.timeZone = TimeZone.getTimeZone("UTC")
 
-                reader.readLine()
+                reader?.readLine()
 
-                var line: String? = reader.readLine()
+                var line: String? = reader?.readLine()
                 while (line != null) {
                     try {
                         val parts = line.split(",")
@@ -110,16 +109,15 @@ class WeightViewModel(private val database: AppDatabase) : ViewModel() {
                             }
                         }
                     } catch (e: Exception) {
-                        Log.e("CSVImport", "Error parsing line: $line", e)
                     }
-                    line = reader.readLine()
+                    line = reader?.readLine()
                 }
 
                 if (entriesToAdd.isNotEmpty()) {
                     database.weightDao().insertAll(entriesToAdd)
                 }
 
-                reader.close()
+                reader?.close()
                 inputStream?.close()
             } catch (e: Exception) {
                 e.printStackTrace()


### PR DESCRIPTION
Implements Habit and HabitEntry models. Adds HabitDao for CRUD operations. Includes Room database migration from v1 to v2 to preserve existing weight data. Updates WeightViewModel to clear habit data on wipe. Closes #8.